### PR TITLE
highlight no-filetype files on open

### DIFF
--- a/plugin/trailing_whitespace.vim
+++ b/plugin/trailing_whitespace.vim
@@ -8,7 +8,7 @@ highlight TrailingWhitespace ctermbg=red guibg=red
 
 augroup trailing_space
   autocmd!
-  autocmd FileType,InsertLeave,TextChanged * call trailing_whitespace#refresh()
+  autocmd FileType,InsertLeave,TextChanged,BufEnter * call trailing_whitespace#refresh()
   autocmd InsertEnter * call trailing_whitespace#clear_highlight(v:true)
 augroup END
 


### PR DESCRIPTION
For exmaple, editing a `.lua-format` file won't trigger refresh on file opening, as its filetype is undetermined (at least on my neovim). I think it's better we highlight files without extensions like this.